### PR TITLE
new lock workflow

### DIFF
--- a/cmd/nanocmd/workflows.go
+++ b/cmd/nanocmd/workflows.go
@@ -9,6 +9,7 @@ import (
 	"github.com/micromdm/nanocmd/workflow/fvenable"
 	"github.com/micromdm/nanocmd/workflow/fvrotate"
 	"github.com/micromdm/nanocmd/workflow/inventory"
+	"github.com/micromdm/nanocmd/workflow/lock"
 	"github.com/micromdm/nanocmd/workflow/profile"
 )
 
@@ -48,6 +49,12 @@ func registerWorkflows(logger log.Logger, r registerer, s *storageConfig, e work
 		return fmt.Errorf("creating cmdplan workflow: %w", err)
 	} else if err = r.RegisterWorkflow(w); err != nil {
 		return fmt.Errorf("registering cmdplan workflow: %w", err)
+	}
+
+	if w, err = lock.New(e, s.inventory, lock.WithLogger(logger)); err != nil {
+		return fmt.Errorf("creating lock workflow: %w", err)
+	} else if err = r.RegisterWorkflow(w); err != nil {
+		return fmt.Errorf("registering lock workflow: %w", err)
 	}
 
 	return nil

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -334,3 +334,10 @@ dock,munki,-uakel,pppc
 ```
 
 Would try to make sure that the profiles with the names of `dock`, `munki`, and `pppc` in the profile subsystem are installed (if they are not already) while making sure the `uakel` profile is removed (if it is installed).
+
+### Lock Workflow
+
+* Workflow name: `io.micromdm.wf.lock.v1`
+* Start value/context: (n/a)
+
+The lock workflow sends the device a lock command using a random PIN code that is escrowed to the inventory subsytem.

--- a/workflow/lock/workflow.go
+++ b/workflow/lock/workflow.go
@@ -1,0 +1,132 @@
+// Pacakge lock implements a DeviceLock PIN escrow workflow.
+package lock
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+
+	"github.com/jessepeterson/mdmcommands"
+	"github.com/micromdm/nanocmd/log"
+	"github.com/micromdm/nanocmd/log/ctxlog"
+	"github.com/micromdm/nanocmd/log/logkeys"
+	"github.com/micromdm/nanocmd/subsystem/inventory/storage"
+	"github.com/micromdm/nanocmd/utils/uuid"
+	"github.com/micromdm/nanocmd/workflow"
+)
+
+const WorkflowName = "io.micromdm.wf.lock.v1"
+
+type Workflow struct {
+	enq    workflow.StepEnqueuer
+	ider   uuid.IDer
+	logger log.Logger
+	store  storage.Storage
+}
+
+type Option func(*Workflow)
+
+func WithLogger(logger log.Logger) Option {
+	return func(w *Workflow) {
+		w.logger = logger
+	}
+}
+
+func New(q workflow.StepEnqueuer, store storage.Storage, opts ...Option) (*Workflow, error) {
+	w := &Workflow{
+		enq:    q,
+		ider:   uuid.NewUUID(),
+		logger: log.NopLogger,
+		store:  store,
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	w.logger = w.logger.With(logkeys.WorkflowName, w.Name())
+	return w, nil
+}
+
+func (w *Workflow) Name() string {
+	return WorkflowName
+}
+
+func (w *Workflow) Config() *workflow.Config {
+	return nil
+}
+
+func (w *Workflow) NewContextValue(name string) workflow.ContextMarshaler {
+	return nil
+}
+
+func randomDigits(n int) string {
+	digits := make([]byte, n)
+	for i := 0; i < n; i++ {
+		digits[i] = byte(rand.Intn(10) + '0')
+	}
+	return string(digits)
+}
+
+func (w *Workflow) Start(ctx context.Context, step *workflow.StepStart) error {
+	for _, id := range step.IDs {
+		// generate us a PIN
+		pin := randomDigits(6)
+
+		// store it in the device's inventory
+		err := w.store.StoreInventoryValues(ctx, id, storage.Values{
+			"lock_pin":            pin,
+			storage.KeyLastSource: WorkflowName,
+		})
+		if err != nil {
+			return fmt.Errorf("store inventory value for %s: %w", id, err)
+		}
+
+		// create MDM command
+		cmd := mdmcommands.NewDeviceLockCommand(w.ider.ID())
+		cmd.Command.PIN = &pin
+
+		// assemble our StepEnqueuing
+		se := step.NewStepEnqueueing()
+		se.IDs = []string{id} // scope to just this ID we're iterating over
+		se.Commands = []interface{}{cmd}
+
+		// enqueue our step!
+		if err = w.enq.EnqueueStep(ctx, w, se); err != nil {
+			return fmt.Errorf("enqueueing step for %s: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func (w *Workflow) StepCompleted(ctx context.Context, stepResult *workflow.StepResult) error {
+	if len(stepResult.CommandResults) != 1 {
+		return workflow.ErrStepResultCommandLenMismatch
+	}
+	response, ok := stepResult.CommandResults[0].(*mdmcommands.DeviceLockResponse)
+	if !ok {
+		return workflow.ErrIncorrectCommandType
+	}
+	if err := response.Validate(); err != nil {
+		return fmt.Errorf("validating rotate response: %w", err)
+	}
+
+	logs := []interface{}{
+		logkeys.InstanceID, stepResult.InstanceID,
+		logkeys.EnrollmentID, stepResult.ID,
+		logkeys.Message, "lock received",
+	}
+	if response.MessageResult != nil && *response.MessageResult != "" {
+		logs = append(logs, "message_result", *response.MessageResult)
+	}
+
+	ctxlog.Logger(ctx, w.logger).Debug(logs...)
+
+	return nil
+}
+
+func (w *Workflow) StepTimeout(_ context.Context, _ *workflow.StepResult) error {
+	return workflow.ErrTimeoutNotUsed
+}
+
+func (w *Workflow) Event(_ context.Context, _ *workflow.Event, _ string, _ *workflow.MDMContext) error {
+	return workflow.ErrEventsNotSupported
+}

--- a/workflow/lock/workflow.go
+++ b/workflow/lock/workflow.go
@@ -106,7 +106,7 @@ func (w *Workflow) StepCompleted(ctx context.Context, stepResult *workflow.StepR
 		return workflow.ErrIncorrectCommandType
 	}
 	if err := response.Validate(); err != nil {
-		return fmt.Errorf("validating rotate response: %w", err)
+		return fmt.Errorf("validating lock response: %w", err)
 	}
 
 	logs := []interface{}{


### PR DESCRIPTION
Create simple device lock workflow that generates a random PIN and escrows it to the inventory system. Implements #22. Tested on a VM. Locked, then unlocked (with the PIN) just fine.