### PR TITLE
fix not found status for retrieving workflow status in MySQL backend

### DIFF
--- a/engine/storage/mysql/storage.go
+++ b/engine/storage/mysql/storage.go
@@ -246,7 +246,9 @@ func (s *MySQLStorage) CancelSteps(ctx context.Context, id, workflowName string)
 // RetrieveWorkflowStarted returns the last time a workflow was started for id.
 func (s *MySQLStorage) RetrieveWorkflowStarted(ctx context.Context, id, workflowName string) (time.Time, error) {
 	ret, err := s.q.GetWorkflowLastStarted(ctx, sqlc.GetWorkflowLastStartedParams{EnrollmentID: id, WorkflowName: workflowName})
-	if err != nil {
+	if errors.Is(err, sql.ErrNoRows) {
+		return time.Time{}, nil
+	} else if err != nil {
 		return time.Time{}, err
 	}
 	parsedTime, err := time.Parse(mySQLTimestampFormat, ret)

--- a/engine/storage/storage.go
+++ b/engine/storage/storage.go
@@ -143,6 +143,7 @@ type StepResult struct {
 
 type WorkflowStatusStorage interface {
 	// RetrieveWorkflowStarted returns the last time a workflow was started for id.
+	// Returned time should be nil with no error if workflowName has not yet been started for id.
 	RetrieveWorkflowStarted(ctx context.Context, id, workflowName string) (time.Time, error)
 
 	// RecordWorkflowStarted stores the started time for workflowName for ids.

--- a/engine/storage/test/event.go
+++ b/engine/storage/test/event.go
@@ -8,6 +8,14 @@ import (
 	"github.com/micromdm/nanocmd/workflow"
 )
 
+func TestEventStatusStorage(t *testing.T, ctx context.Context, store storage.WorkflowStatusStorage) {
+	_, err := store.RetrieveWorkflowStarted(ctx, "id.should.not.exist", "wfname.whaa")
+	if err != nil {
+		// should not error for a non-found item
+		t.Fatal(err)
+	}
+}
+
 func TestEventStorage(t *testing.T, store storage.EventSubscriptionStorage) {
 	ctx := context.Background()
 

--- a/engine/storage/test/test.go
+++ b/engine/storage/test/test.go
@@ -42,6 +42,12 @@ func TestEngineStorage(t *testing.T, newStorage func() storage.AllStorage) {
 	t.Run("testEvent", func(t *testing.T) {
 		TestEventStorage(t, s)
 	})
+
+	ctx := context.Background()
+
+	t.Run("testEventStatus", func(t *testing.T) {
+		TestEventStatusStorage(t, ctx, s)
+	})
 }
 
 func mainTest(t *testing.T, s storage.AllStorage) {


### PR DESCRIPTION
Workflows status retrieval would return an error if they hadn't already run: `sql: no rows in result set` using the MySQL driver. This should simply return nil if it has not been found. Add regression test.