### PR TITLE
use UTC in MySQL backend for workflow started timestamp

### DIFF
--- a/cmd/nanocmd/storage.go
+++ b/cmd/nanocmd/storage.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	storageeng "github.com/micromdm/nanocmd/engine/storage"
 	storageengdiskv "github.com/micromdm/nanocmd/engine/storage/diskv"
@@ -69,6 +71,9 @@ func parseStorage(name, dsn string) (*storageConfig, error) {
 			filevault: fv,
 		}, nil
 	case "mysql":
+		if strings.Contains(dsn, "parseTime=true") {
+			return nil, errors.New("parseTime=true unsupported")
+		}
 		inv := storageinvinmem.New()
 		fv, err := storagefvinmem.New(storagefvinvprk.NewInvPRK(inv))
 		if err != nil {

--- a/engine/storage/mysql/mysql.go
+++ b/engine/storage/mysql/mysql.go
@@ -87,6 +87,17 @@ func sqlNullTime(t time.Time) sql.NullTime {
 	return sql.NullTime{Valid: !t.IsZero(), Time: t}
 }
 
+// fromSQLTimestamp converts a TIMESTAMP column ts to a Go time.
+// The timestamp is assumed to be UTC.
+func fromSQLTimestamp(ts string) (time.Time, error) {
+	return time.Parse(mySQLTimestampFormat, ts)
+}
+
+// toSQLTimestamp returns a string representation of t in UTC.
+func toSQLTimestamp(t time.Time) string {
+	return t.UTC().Format(mySQLTimestampFormat)
+}
+
 // txcb executes SQL within transactions when wrapped in tx().
 type txcb func(ctx context.Context, tx *sql.Tx, qtx *sqlc.Queries) error
 

--- a/engine/storage/mysql/query.sql
+++ b/engine/storage/mysql/query.sql
@@ -154,8 +154,11 @@ WHERE
   s.workflow_name = ?;
 
 -- name: GetWorkflowLastStarted :one
+-- Note we add a CONCAT() to the dynamic column to trick sqlc into treating
+-- this CONVERT_TZ() column as a string instead of a time.Time{} column.
+-- See sqlc-dev/sqlc#2800 for "type annotations" as a future path forward.
 SELECT
-  last_created_at
+  CONCAT(CONVERT_TZ(last_created_at, @@session.time_zone, '+00:00')) AS last_created_at_utc
 FROM
   wf_status
 WHERE

--- a/engine/storage/test/test.go
+++ b/engine/storage/test/test.go
@@ -273,11 +273,7 @@ func mainTest(t *testing.T, s storage.AllStorage) {
 			// 	t.Fatalf("invalid test data: step enqueueing with config: %v", err)
 			// }
 
-			// some backends may truncate the time and drop TZ
-			// so let's truncate ourselves and eliminate the TZ.
-			// since this value is used to compare the retrived value
-			// we'll stick with that.
-			storedAt := time.Now().UTC().Truncate(time.Second)
+			storedAt := time.Now()
 
 			err := s.StoreStep(ctx, tStep.step, storedAt)
 			if tStep.shouldError && err == nil {
@@ -301,8 +297,9 @@ func mainTest(t *testing.T, s storage.AllStorage) {
 					}
 					if ts.IsZero() {
 						t.Errorf("RetrieveWorkflowStarted: nil timestamp for id=%s, step=%s err=%v", id, tStep.step.WorkflowName, err)
-					} else if ts != storedAt {
-						t.Errorf("RetrieveWorkflowStarted: timestamp mismatch for id=%s, step=%s expected=%v got=%v", id, tStep.step.WorkflowName, storedAt, ts)
+					} else if t1, t2 := ts.Truncate(time.Second), storedAt.Truncate(time.Second); t1.Compare(t2) != 0 {
+						// truncate comparison in case backends don't persist precision less than 1s (e.g. SQL textual dates)
+						t.Errorf("RetrieveWorkflowStarted: timestamp mismatch for id=%s, step=%s expected=%v got=%v compare=%v", id, tStep.step.WorkflowName, t2, t1, t1.Compare(t2))
 					}
 				}
 			}


### PR DESCRIPTION
Appropriately handle timestamps for the ["workflow started" engine storage interfaces](https://github.com/micromdm/nanocmd/blob/4707327ae775af1a6bff68baab6216692568979d/engine/storage/storage.go#L144-L154) in the MySQL storage backend.

We had a few critical issues with this—namely from using a MySQL `TIMESTAMP` column and using a normal `time.Now()` value:

* `TIMESTAMP` columns *convert* to UTC for storage, but always parse and present the MySQL system/session local timezone. From the [manual](https://dev.mysql.com/doc/refman/8.4/en/datetime.html): "MySQL converts TIMESTAMP values from the current time zone to UTC for storage, and back from UTC to the current time zone for retrieval."
* This was especially a problem because we took the `time.Time{}` (i.e. `time.Now()` with the local TZ) value as-is and simply converted it to a string and stored it.
* In a typical scenario this meant that while a timestamp was inserted as the local TZ (and converted for storage by MySQL to UTC) but when MySQL read it back (as the local TZ) we utilized UTC to parse the time. This meant it was always off by the local MySQL TZ offset in Go.
* Further if the TZ of the MySQL session was different (say, your MySQL server is in a different TZ than your server code) then not only would the above issue exist, but it'd be even more problematic as the local TZ time would be interpreted as the MySQL session TZ and UTC calculated from that for the storage of the timestamp.

To address all that we now explicitly convert the input Go `time.Time{}` to UTC, then use MySQL `CONVERT_TZ()` to convert that UTC timestamp to the session TZ (and: yes, just for MySQL to convert it right back to UTC for storage). As well for reading we ask MySQL to convert from the "presented" session TZ back to UTC (again using `CONVERT_TZ()`) so that Go can use UTC when parsing the queried time. This keeps everything in UTC for the date math in Golang. Updated the tests.

An alternate solve for this was to add another storage interface method that explicitly do the date math in the storage backend. E.g. something like `IsWorkflowStartedBefore(time.Duration)`. That may still be a good choice for the future.

I've been warned against using `TIMESTAMP` columns in general with MySQL. I was a cavalier with that advice. This is the prize.