### PR TITLE
use epoch for wf started column in MySQL backend

### DIFF
--- a/engine/storage/mysql/query.sql
+++ b/engine/storage/mysql/query.sql
@@ -155,7 +155,7 @@ WHERE
 
 -- name: GetWorkflowLastStarted :one
 SELECT
-  last_created_at
+  last_created_unix
 FROM
   wf_status
 WHERE

--- a/engine/storage/mysql/schema.00002.sql
+++ b/engine/storage/mysql/schema.00002.sql
@@ -1,0 +1,3 @@
+ALTER TABLE wf_status
+    DROP COLUMN last_created_at,
+    ADD COLUMN last_created_unix BIGINT NOT NULL DEFAULT (UNIX_TIMESTAMP());

--- a/engine/storage/mysql/schema.sql
+++ b/engine/storage/mysql/schema.sql
@@ -84,7 +84,11 @@ CREATE TABLE wf_status (
     enrollment_id VARCHAR(255) NOT NULL,
     workflow_name VARCHAR(255) NOT NULL,
 
-    last_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    -- this was intended to be "DEFAULT (UNIX_TIMESTAMP() * 1000)"
+    -- which would complement the Golang `time.Time{}.UnixMilli()`.
+    -- however sqlc seems to not support that syntax, so we'll settle
+    -- for less precision.
+    last_created_unix BIGINT NOT NULL DEFAULT (UNIX_TIMESTAMP()),
 
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/engine/storage/mysql/sqlc/models.go
+++ b/engine/storage/mysql/sqlc/models.go
@@ -53,9 +53,9 @@ type WfEvent struct {
 }
 
 type WfStatus struct {
-	EnrollmentID  string
-	WorkflowName  string
-	LastCreatedAt string
-	CreatedAt     sql.NullTime
-	UpdatedAt     sql.NullTime
+	EnrollmentID    string
+	WorkflowName    string
+	LastCreatedUnix int64
+	CreatedAt       sql.NullTime
+	UpdatedAt       sql.NullTime
 }

--- a/engine/storage/mysql/sqlc/query.sql.go
+++ b/engine/storage/mysql/sqlc/query.sql.go
@@ -376,7 +376,7 @@ func (q *Queries) GetStepByID(ctx context.Context, id int64) (GetStepByIDRow, er
 
 const getWorkflowLastStarted = `-- name: GetWorkflowLastStarted :one
 SELECT
-  last_created_at
+  last_created_unix
 FROM
   wf_status
 WHERE
@@ -389,11 +389,11 @@ type GetWorkflowLastStartedParams struct {
 	WorkflowName string
 }
 
-func (q *Queries) GetWorkflowLastStarted(ctx context.Context, arg GetWorkflowLastStartedParams) (string, error) {
+func (q *Queries) GetWorkflowLastStarted(ctx context.Context, arg GetWorkflowLastStartedParams) (int64, error) {
 	row := q.db.QueryRowContext(ctx, getWorkflowLastStarted, arg.EnrollmentID, arg.WorkflowName)
-	var last_created_at string
-	err := row.Scan(&last_created_at)
-	return last_created_at, err
+	var last_created_unix int64
+	err := row.Scan(&last_created_unix)
+	return last_created_unix, err
 }
 
 const removeIDCommandsByStepID = `-- name: RemoveIDCommandsByStepID :exec

--- a/engine/storage/test/test.go
+++ b/engine/storage/test/test.go
@@ -273,7 +273,7 @@ func mainTest(t *testing.T, s storage.AllStorage) {
 			// 	t.Fatalf("invalid test data: step enqueueing with config: %v", err)
 			// }
 
-			storedAt := time.Now().UTC()
+			storedAt := time.Now()
 
 			err := s.StoreStep(ctx, tStep.step, storedAt)
 			if tStep.shouldError && err == nil {


### PR DESCRIPTION
Store the workflow-started value as a MySQL `BIGINT` column containing the Unix epoch seconds instead of a `TIMESTAMP` column.  This fixes a problem with timezones as described in detail in #71. This is an alternative to all the `CONVERT_TZ()` nonsense in that PR at the expense of schema changes.