### PR TITLE
deadlock mitigation redux

### DIFF
--- a/engine/storage/mysql/query.sql
+++ b/engine/storage/mysql/query.sql
@@ -127,7 +127,7 @@ FROM
 WHERE
   id = ?;
 
--- name: GetIDCommandsByStepID :many
+-- name: GetIDCommandsByStepIDAndLock :many
 SELECT
   ic.command_uuid,
   ic.request_type,

--- a/engine/storage/mysql/query.sql
+++ b/engine/storage/mysql/query.sql
@@ -67,6 +67,17 @@ WHERE
   c.step_id IS NULL AND
   s.workflow_name = ?;
 
+-- name: DeleteWorkflowStepHavingNoCommandsByStepID :exec
+DELETE
+  s
+FROM
+  steps s
+  LEFT JOIN id_commands c
+    ON s.id = c.step_id
+WHERE
+  c.step_id IS NULL AND
+  s.id = ?;
+
 -- name: UpdateIDCommandTimestamp :exec
 UPDATE
   id_commands
@@ -118,24 +129,19 @@ WHERE
 
 -- name: GetIDCommandsByStepID :many
 SELECT
-  command_uuid,
-  request_type,
-  result
+  ic.command_uuid,
+  ic.request_type,
+  ic.result
 FROM
-  id_commands
+  id_commands ic
+  INNER JOIN steps s
+    ON ic.step_id = s.id
+  LEFT JOIN step_commands sc
+    ON sc.step_id = s.id
 WHERE
-  enrollment_id = ? AND
-  step_id = ? AND
-  completed != 0;
-
--- name: LockIDCommandsByStepID :exec
-SELECT
-  command_uuid
-FROM
-  id_commands
-WHERE
-  enrollment_id = ? AND
-  step_id = ?
+  ic.enrollment_id = ? AND
+  s.id = ? AND
+  ic.completed != 0
 FOR UPDATE;
 
 -- name: RemoveIDCommandsByStepID :exec

--- a/engine/storage/mysql/sqlc/query.sql.go
+++ b/engine/storage/mysql/sqlc/query.sql.go
@@ -239,7 +239,7 @@ func (q *Queries) DeleteWorkflowStepHavingNoCommandsByWorkflowName(ctx context.C
 	return err
 }
 
-const getIDCommandsByStepID = `-- name: GetIDCommandsByStepID :many
+const getIDCommandsByStepIDAndLock = `-- name: GetIDCommandsByStepIDAndLock :many
 SELECT
   ic.command_uuid,
   ic.request_type,
@@ -257,26 +257,26 @@ WHERE
 FOR UPDATE
 `
 
-type GetIDCommandsByStepIDParams struct {
+type GetIDCommandsByStepIDAndLockParams struct {
 	EnrollmentID string
 	ID           int64
 }
 
-type GetIDCommandsByStepIDRow struct {
+type GetIDCommandsByStepIDAndLockRow struct {
 	CommandUuid string
 	RequestType string
 	Result      []byte
 }
 
-func (q *Queries) GetIDCommandsByStepID(ctx context.Context, arg GetIDCommandsByStepIDParams) ([]GetIDCommandsByStepIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, getIDCommandsByStepID, arg.EnrollmentID, arg.ID)
+func (q *Queries) GetIDCommandsByStepIDAndLock(ctx context.Context, arg GetIDCommandsByStepIDAndLockParams) ([]GetIDCommandsByStepIDAndLockRow, error) {
+	rows, err := q.db.QueryContext(ctx, getIDCommandsByStepIDAndLock, arg.EnrollmentID, arg.ID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []GetIDCommandsByStepIDRow
+	var items []GetIDCommandsByStepIDAndLockRow
 	for rows.Next() {
-		var i GetIDCommandsByStepIDRow
+		var i GetIDCommandsByStepIDAndLockRow
 		if err := rows.Scan(&i.CommandUuid, &i.RequestType, &i.Result); err != nil {
 			return nil, err
 		}

--- a/engine/storage/mysql/storage.go
+++ b/engine/storage/mysql/storage.go
@@ -97,7 +97,7 @@ func (s *MySQLStorage) StoreCommandResponseAndRetrieveCompletedStep(ctx context.
 			Commands: []storage.StepCommandResult{*sc},
 		}
 
-		cmdR, err := qtx.GetIDCommandsByStepID(ctx, sqlc.GetIDCommandsByStepIDParams{
+		cmdR, err := qtx.GetIDCommandsByStepIDAndLock(ctx, sqlc.GetIDCommandsByStepIDAndLockParams{
 			EnrollmentID: id,
 			ID:           cmdCt.StepID,
 		})

--- a/engine/storage/mysql/storage.go
+++ b/engine/storage/mysql/storage.go
@@ -97,17 +97,9 @@ func (s *MySQLStorage) StoreCommandResponseAndRetrieveCompletedStep(ctx context.
 			Commands: []storage.StepCommandResult{*sc},
 		}
 
-		err = qtx.LockIDCommandsByStepID(ctx, sqlc.LockIDCommandsByStepIDParams{
-			EnrollmentID: id,
-			StepID:       cmdCt.StepID,
-		})
-		if err != nil {
-			return fmt.Errorf("lock commands by step by id (%d): %w", cmdCt.StepID, err)
-		}
-
 		cmdR, err := qtx.GetIDCommandsByStepID(ctx, sqlc.GetIDCommandsByStepIDParams{
 			EnrollmentID: id,
-			StepID:       cmdCt.StepID,
+			ID:           cmdCt.StepID,
 		})
 		if err != nil {
 			return fmt.Errorf("get id commands by step by id (%d): %w", cmdCt.StepID, err)
@@ -130,9 +122,9 @@ func (s *MySQLStorage) StoreCommandResponseAndRetrieveCompletedStep(ctx context.
 			return fmt.Errorf("remove id commands by step by id (%d): %w", cmdCt.StepID, err)
 		}
 
-		err = qtx.DeleteWorkflowStepHavingNoCommandsByWorkflowName(ctx, sd.WorkflowName)
+		err = qtx.DeleteWorkflowStepHavingNoCommandsByStepID(ctx, cmdCt.StepID)
 		if err != nil {
-			return fmt.Errorf("delete workflow with no commands (%s): %w", sd.WorkflowName, err)
+			return fmt.Errorf("delete workflow with no commands (%d): %w", cmdCt.StepID, err)
 		}
 
 		return nil


### PR DESCRIPTION
While I thought we addressed this in #75 it was not. There are two delete operations: one for the commands and one for the step. I believe we mitigated the command deletion deadlock with #75 but the step deletion deadlock remained. To help with this we:

* rolled the row locks into the step id command retrieval query vs. a separate lock query.
  * also using joins to extend the lock, even though we aren't using that joined info
* narrowed the step deletion to just be related to the relevant command step, rather than all steps which *should* already be locked due to the above.

Hopefully this gets us where we need to be. Both Go unit tests and `mdmb` tests were done to verify operation.