### PR TITLE
new certprof workflow

### DIFF
--- a/cmd/nanocmd/workflows.go
+++ b/cmd/nanocmd/workflows.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/micromdm/nanocmd/workflow"
+	"github.com/micromdm/nanocmd/workflow/certprof"
 	"github.com/micromdm/nanocmd/workflow/cmdplan"
 	"github.com/micromdm/nanocmd/workflow/fvenable"
 	"github.com/micromdm/nanocmd/workflow/fvrotate"
@@ -56,6 +57,12 @@ func registerWorkflows(logger log.Logger, r registerer, s *storageConfig, e work
 		return fmt.Errorf("creating lock workflow: %w", err)
 	} else if err = r.RegisterWorkflow(w); err != nil {
 		return fmt.Errorf("registering lock workflow: %w", err)
+	}
+
+	if w, err = certprof.New(e, s.profile, certprof.WithLogger(logger)); err != nil {
+		return fmt.Errorf("creating certprof workflow: %w", err)
+	} else if err = r.RegisterWorkflow(w); err != nil {
+		return fmt.Errorf("registering certprof workflow: %w", err)
 	}
 
 	return nil

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -277,10 +277,10 @@ The certificate-profile workflow conditionally installs configuration profiles (
 
 The workflow's context determines details about how the workflow runs. The four main keys are:
 
-* `name`: Profile name in the profile storage to use.
+* `profile`: Profile name in profile storage to install (before text replacement).
 * `criteria`: Used to determine whether to replace a found certificate.
 * `filter`: Used to find the particular certificate in the list of certificates.
-* `text_replacements`: Used to perform simple text find-and-replace on the profile before installing it.
+* `text_replacements`: Optionally used to perform simple text find-and-replace on the profile before installing it.
 
 Example JSON object:
 
@@ -297,7 +297,8 @@ Example JSON object:
         "%CN%": "kai",
         "%CHAL%": "secret"
     }
-}```
+}
+```
 
 ### Command Plan Workflow
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -260,6 +260,45 @@ The inventory subsystem provides storage backends for "inventory" data — that
 
 Workflows are domain-specific, contained, and encapsulated MDM command sequence senders and processors. For a higher level review of workflows check out the [README](../README.md). For more information about the internals and implementation of workflows please read [the package documentation](../workflow/doc.go).
 
+### Certificate-Profile Workflow
+
+* Workflow name: `io.micromdm.wf.certprof.v1`
+* Start value/context: JSON object, see below.
+
+The certificate-profile workflow conditionally installs configuration profiles (ostensibly certificate identity profiles) based on output from the MDM `CertificateList` profile. It does this, roughly, by doing these steps:
+
+1. Sending the MDM `CertificateList` command.
+1. Receiving the list of certificates and applying the *filter* (below) to find a single matching certificate.
+1. If a certificate is found then checking that it against *criteria* (below) to determine if it needs to be replaced (and thus, the profile being installed)
+1. If no certificiate is found then the profile proceeds to be installed.
+1. If the certificate exists and criteria is not such that it needs to be replaced, then the workflow ends before installing the profile.
+
+#### Context (input parameters)
+
+The workflow's context determines details about how the workflow runs. The four main keys are:
+
+* `name`: Profile name in the profile storage to use.
+* `criteria`: Used to determine whether to replace a found certificate.
+* `filter`: Used to find the particular certificate in the list of certificates.
+* `text_replacements`: Used to perform simple text find-and-replace on the profile before installing it.
+
+Example JSON object:
+
+```json
+{
+    "criteria": {
+        "always_replace": true
+    },
+    "filter": {
+        "cn_prefix": "kai"
+    },
+    "profile": "scep",
+    "text_replacements": {
+        "%CN%": "kai",
+        "%CHAL%": "secret"
+    }
+}```
+
 ### Command Plan Workflow
 
 * Workflow name: `io.micromdm.wf.cmdplan.v1`

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -265,7 +265,7 @@ Workflows are domain-specific, contained, and encapsulated MDM command sequence 
 * Workflow name: `io.micromdm.wf.certprof.v1`
 * Start value/context: JSON object, see below.
 
-The certificate-profile workflow conditionally installs configuration profiles (ostensibly certificate identity profiles) based on output from the MDM `CertificateList` profile. It does this, roughly, by doing these steps:
+The certificate-profile workflow conditionally installs configuration profiles (ostensibly certificate identity profiles) based on output from the MDM `CertificateList` command. It does this, roughly, by doing these steps:
 
 1. Sending the MDM `CertificateList` command.
 1. Receiving the list of certificates and applying the *filter* (below) to find a single matching certificate.

--- a/subsystem/profile/storage/storage.go
+++ b/subsystem/profile/storage/storage.go
@@ -27,6 +27,14 @@ func (p *ProfileInfo) Valid() bool {
 	return true
 }
 
+type ReadRawStorage interface {
+	// RetrieveRawProfiles returns the raw profile bytes by name.
+	// Implementations should not return all profiles if no names were provided.
+	// ErrProfileNotFound is returned for any name that hasn't been stored.
+	// ErrNoNames is returned if names is empty.
+	RetrieveRawProfiles(ctx context.Context, names []string) (map[string][]byte, error)
+}
+
 type ReadStorage interface {
 	// RetrieveProfileInfos returns the profile metadata by name.
 	// Implementations have the choice to return all profile metadata if
@@ -34,11 +42,7 @@ type ReadStorage interface {
 	// any name that hasn't been stored.
 	RetrieveProfileInfos(ctx context.Context, names []string) (map[string]ProfileInfo, error)
 
-	// RetrieveRawProfiles returns the raw profile bytes by name.
-	// Implementations should not return all profiles if no names were provided.
-	// ErrProfileNotFound is returned for any name that hasn't been stored.
-	// ErrNoNames is returned if names is empty.
-	RetrieveRawProfiles(ctx context.Context, names []string) (map[string][]byte, error)
+	ReadRawStorage
 }
 
 type Storage interface {

--- a/workflow/certprof/context.go
+++ b/workflow/certprof/context.go
@@ -1,0 +1,76 @@
+package certprof
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+var (
+	ErrNilContext       = errors.New("nil context")
+	ErrEmptyProfileName = errors.New("empty profile name provided")
+	ErrEmptyFilter      = errors.New("empty filter")
+)
+
+// Filter filters the returned CertificateList certificates by maching attributes.
+type Filter struct {
+	// CNPrefix matches certificates based on the CN prefix matching this string.
+	CNPrefix string `json:"cn_prefix,omitempty"`
+
+	// NoRequireIdentity disables the requirement of the certificate
+	// to be marked as an Identity in the CertificateList response.
+	NoRequireIdentity bool `json:"require_identity,omitempty"`
+}
+
+// Criteria specifies how to check that certificate should be replaced.
+type Criteria struct {
+	// AlwaysReplace is just that: a forcing mechanism to always replace the certificate.
+	AlwaysReplace bool `json:"always_replace,omitempty"`
+
+	// UntilExpirySeconds checks that the certificate NotAfter timestamp is still valid.
+	// I.e. this is intended to check that a certificate should be replaced
+	// before it expires.
+	// E.g. a value of 300 would mean that a certificate should be replaced
+	// if the certificate NotAfter time is within 5 minutes of expiring (or already expired).
+	UntilExpirySeconds int `json:"until_expiry_sec,omitempty"`
+}
+
+// Context configures workflow behavior.
+type Context struct {
+	// NoManagedOnly turns off the default behavior setting "ManagedOnly" to
+	// true in the CertificateList command.
+	NoManagedOnly bool `json:"no_managed_only,omitempty"`
+
+	// Profile specifies the name of the profile to install.
+	// Text replacements will be performed on this profile, if they exist.
+	Profile string `json:"profile"`
+
+	// TextReplacements represent dynamic replacements
+	TextReplacements map[string]string `json:"text_replacements,omitempty"`
+
+	Filter   *Filter   `json:"filter,omitempty"`
+	Criteria *Criteria `json:"criteria,omitempty"`
+}
+
+// Validate checks to make sure c is valid, dependong on step name.
+func (c *Context) Validate(_ string) error {
+	if c == nil {
+		return ErrNilContext
+	}
+	if c.Profile == "" {
+		return ErrEmptyProfileName
+	}
+	if c.Filter == nil {
+		return ErrEmptyFilter
+	}
+	return nil
+}
+
+// MarshalBinary marshals c into JSON data.
+func (c *Context) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(c)
+}
+
+// UnmarshalBinary unmarshals JSON data into c.
+func (c *Context) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, c)
+}

--- a/workflow/certprof/context.go
+++ b/workflow/certprof/context.go
@@ -16,9 +16,9 @@ type Filter struct {
 	// CNPrefix matches certificates based on the CN prefix matching this string.
 	CNPrefix string `json:"cn_prefix,omitempty"`
 
-	// NoRequireIdentity disables the requirement of the certificate
+	// AllowNonIdentity disables the requirement of the certificate
 	// to be marked as an Identity in the CertificateList response.
-	NoRequireIdentity bool `json:"require_identity,omitempty"`
+	AllowNonIdentity bool `json:"allow_non_identity,omitempty"`
 }
 
 // Criteria specifies how to check that certificate should be replaced.

--- a/workflow/certprof/process.go
+++ b/workflow/certprof/process.go
@@ -63,7 +63,7 @@ func filter(f *Filter, in []mdmcommands.CertificateListItem) (out []mdmcommands.
 	}
 	for _, item := range in {
 		// skip if cert is not an identity
-		if !f.NoRequireIdentity && !item.IsIdentity {
+		if !f.AllowNonIdentity && !item.IsIdentity {
 			continue
 		}
 

--- a/workflow/certprof/process.go
+++ b/workflow/certprof/process.go
@@ -1,0 +1,200 @@
+package certprof
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jessepeterson/mdmcommands"
+	"github.com/micromdm/nanocmd/logkeys"
+	"github.com/micromdm/nanocmd/workflow"
+	"github.com/micromdm/nanolib/log/ctxlog"
+)
+
+// Start starts the workflow.
+func (w *Workflow) Start(ctx context.Context, step *workflow.StepStart) error {
+	// load and validate the workflow context
+	wfCtx, ok := step.Context.(*Context)
+	if !ok {
+		return workflow.ErrInvalidContext
+	}
+	if err := wfCtx.Validate(step.Name); err != nil {
+		return fmt.Errorf("validating context: %w", err)
+	}
+
+	// assemble the CertificateList MDM command
+	cmd := mdmcommands.NewCertificateListCommand(w.ider.ID())
+
+	if !wfCtx.NoManagedOnly {
+		managedOnly := true
+		cmd.Command.ManagedOnly = &managedOnly
+	}
+
+	// assemble our StepEnqueuing
+	se := step.NewStepEnqueueing()
+	// add our command
+	se.Commands = []interface{}{cmd}
+	// pass along our context to the subsequent step completions
+	se.Context = wfCtx
+
+	// enqueue the step!
+	return w.enq.EnqueueStep(ctx, w, se)
+}
+
+// replace replaces instances of r's map keys with their values.
+func replace(in string, r map[string]string) string {
+	if len(in) < 1 || r == nil || len(r) < 1 {
+		return in
+	}
+	oldnews := make([]string, 0, len(r)*2)
+	for k, v := range r {
+		oldnews = append(oldnews, k, v)
+	}
+	repl := strings.NewReplacer(oldnews...)
+	return repl.Replace(in)
+}
+
+// filter in using f.
+func filter(f *Filter, in []mdmcommands.CertificateListItem) (out []mdmcommands.CertificateListItem) {
+	if f == nil {
+		return
+	}
+	for _, item := range in {
+		// skip if cert is not an identity
+		if !f.NoRequireIdentity && !item.IsIdentity {
+			continue
+		}
+
+		// skip if no CN prefix match
+		if f.CNPrefix != "" && !strings.HasPrefix(item.CommonName, f.CNPrefix) {
+			continue
+		}
+
+		out = append(out, item)
+	}
+	return
+}
+
+// checkCriteria compares item against c to determine whether it should be replaced (re-installed).
+func checkCriteria(c *Criteria, item *mdmcommands.CertificateListItem) (replace bool, reason string, err error) {
+	if c == nil {
+		// if there is no criteria then the mere existence of the cert
+		// means we should never replace it.
+		return false, "nil criteria", nil
+	}
+
+	if c.AlwaysReplace {
+		return true, "always replace", nil
+	}
+
+	if c.UntilExpirySeconds > 0 {
+		crt, err := x509.ParseCertificate(item.Data)
+		if err != nil {
+			return true, "error", fmt.Errorf("parse certificate: %w", err)
+		}
+
+		if time.Until(crt.NotAfter) < (time.Duration(c.UntilExpirySeconds) * time.Second) {
+			return true, fmt.Sprintf("certificate NotAfter Until: %d; less than expiry: %d", time.Until(crt.NotAfter), c.UntilExpirySeconds), nil
+		}
+	}
+
+	return false, "default false replace", nil
+}
+
+// certListStepCompleted occurs when the certificate list response is received.
+func (w *Workflow) certListStepCompleted(ctx context.Context, stepResult *workflow.StepResult) error {
+	// validate the correct MDM response
+	if len(stepResult.CommandResults) != 1 {
+		return workflow.ErrStepResultCommandLenMismatch
+	}
+	response, ok := stepResult.CommandResults[0].(*mdmcommands.CertificateListResponse)
+	if !ok {
+		return workflow.ErrIncorrectCommandType
+	}
+	if err := response.Validate(); err != nil {
+		return fmt.Errorf("validating certificate list response: %w", err)
+	}
+
+	// validate the (carried over) workflow context
+	wfCtx, ok := stepResult.Context.(*Context)
+	if !ok {
+		return workflow.ErrInvalidContext
+	}
+	if err := wfCtx.Validate(stepResult.Name); err != nil {
+		return fmt.Errorf("validating context: %w", err)
+	}
+
+	logger := ctxlog.Logger(ctx, w.logger)
+
+	// try and match the single certificate we want to replace
+	cl := filter(wfCtx.Filter, response.CertificateList)
+
+	if len(cl) > 1 {
+		return fmt.Errorf("too many certs after filter: %d; before filter: %d", len(cl), len(response.CertificateList))
+	} else if len(cl) == 1 {
+		replace, reason, err := checkCriteria(wfCtx.Criteria, &cl[0])
+		if err != nil {
+			return fmt.Errorf("checking criteria: %w", err)
+		}
+		if !replace {
+			// checkCriteria has determined this certificate need not be replaced.
+			logger.Debug(logkeys.Message, fmt.Sprintf("not installing profile: %s", reason))
+			// so simply exit gracefully.
+			return nil
+		}
+		logger.Debug(logkeys.Message, fmt.Sprintf("installing profile: %s", reason))
+	} else { // i.e. no certs
+		logger.Debug(logkeys.Message, "no certificate found; installing profile")
+	}
+
+	profiles, err := w.store.RetrieveRawProfiles(ctx, []string{wfCtx.Profile})
+	if err != nil {
+		return fmt.Errorf("retrieving raw profile: %s: %w", wfCtx.Profile, err)
+	}
+
+	// replace values
+	profile := replace(string(profiles[wfCtx.Profile]), wfCtx.TextReplacements)
+
+	// assemble the MDM command
+	cmd := mdmcommands.NewInstallProfileCommand(w.ider.ID())
+	cmd.Command.Payload = []byte(profile)
+
+	// create the step
+	se := stepResult.NewStepEnqueueing()
+	se.Name = stepNameProfile
+	se.Commands = []interface{}{cmd}
+	// we abandon our context here, as we're not using it for the install profile response
+
+	return w.enq.EnqueueStep(ctx, w, se)
+}
+
+// certListStepCompleted occurs when the install profile response is received.
+func (w *Workflow) profileStepCompleted(_ context.Context, stepResult *workflow.StepResult) error {
+	// validate the correct MDM response
+	if len(stepResult.CommandResults) != 1 {
+		return workflow.ErrStepResultCommandLenMismatch
+	}
+	response, ok := stepResult.CommandResults[0].(*mdmcommands.InstallProfileResponse)
+	if !ok {
+		return workflow.ErrIncorrectCommandType
+	}
+	if err := response.Validate(); err != nil {
+		return fmt.Errorf("validating install profile response: %w", err)
+	}
+
+	return nil
+}
+
+// StepCompleted occurs when any workflow step is completed.
+func (w *Workflow) StepCompleted(ctx context.Context, stepResult *workflow.StepResult) error {
+	switch stepResult.Name {
+	case "":
+		return w.certListStepCompleted(ctx, stepResult)
+	case stepNameProfile:
+		return w.profileStepCompleted(ctx, stepResult)
+	default:
+		return fmt.Errorf("%w: %s", workflow.ErrUnknownStepName, stepResult.Name)
+	}
+}

--- a/workflow/certprof/testdata/certlist.plist
+++ b/workflow/certprof/testdata/certlist.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CertificateList</key>
+	<array>
+		<dict>
+			<key>CommonName</key>
+			<string>?Error_-26276?</string>
+			<key>Data</key>
+			<data>
+			MIIDHTCCAgWgAwIBAgIBYjANBgkqhkiG9w0BAQsFADA7MQswCQYD
+			VQQGEwJVUzENMAsGA1UEChMEc2NlcDEQMA4GA1UECxMHU0NFUCBD
+			QTELMAkGA1UEAxMCY2EwHhcNMjQwNTAyMTczMzMxWhcNMzQwNDMw
+			MTc0MzMxWjAAMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+			AQEAobyuGhY/h4sIntIiWuXCfiBy5Fn95mYECOhIn4qzryz1OdjS
+			p253CxaNI/3C7xB3Z2GQllmFk1J5zhma5ZT8KuBiztKBfTQ003T8
+			Xjqg8Bw5WNSNu/w12DfxwV1J1ADeg6/ZAIXoKNtQwy9FlhV4TT1M
+			xWYgHBoJq7V8pg/+MxvI0cMnKR0PLySZsxLWETJ2xhlSxakspqe2
+			IlVBQHLpqw5xR5Z2a9BfBpf/npnslGtccAnUouOLgu3nnewFzACK
+			qS27aCZ9ycYx942UtidHM/XWp80jKzUprHVw79ToCopNPnEkV+a/
+			bbu2Idrl0SbijTONj79vYPC7sWazfZPE/QIDAQABo2cwZTAOBgNV
+			HQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAwIwHQYDVR0O
+			BBYEFF+7Qr9PbAGxYGWOp2mbt/T6QhRqMB8GA1UdIwQYMBaAFPlN
+			RegzeawfJsKNy3xHIe46k+voMA0GCSqGSIb3DQEBCwUAA4IBAQA6
+			UryVq/ofAgrCWM2F0ccFT2goQx8WUyOo12MQgGxRjRL8d80SPU/W
+			kfyFrF4rFrIniF8haw/yz9wE7StXZTYO3TKo/SRpgnOQEkZsoTEI
+			TjAVuVO9SiTwaP22bk7Z2QsoKAsEsEoax8nkafKr0DGA72mjt0WO
+			mKDC9bo1CuOVWkscOx49VO8cM4dIKSR+HXAIGU0buQKgF++MUxCH
+			apYGXdckrpIXjeFWVTsdc0ATDGRokH5bWFnP938f++82fSyDAyhl
+			qvxR9VK+3gmMMoyn3pyLXo5lnZVz0GU/l+BM6rqayBUaEoeCbvFh
+			kVjhdXJYw6KY6ttYXuL1DVGvHo/s
+			</data>
+			<key>IsIdentity</key>
+			<true/>
+		</dict>
+	</array>
+	<key>CommandUUID</key>
+	<string>CERT-LIST-01</string>
+	<key>Status</key>
+	<string>Acknowledged</string>
+	<key>UDID</key>
+	<string>6362F867-FFF2-4EA6-905C-3C796DF4EF68</string>
+</dict>
+</plist>
+

--- a/workflow/certprof/testdata/resp-ack.plist
+++ b/workflow/certprof/testdata/resp-ack.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CommandUUID</key>
+	<string>D053EE3A-EE0E-4E82-87D2-BB3624186694</string>
+	<key>Status</key>
+	<string>Acknowledged</string>
+	<key>UDID</key>
+	<string>6362F867-FFF2-4EA6-905C-3C796DF4EF68</string>
+</dict>
+</plist>

--- a/workflow/certprof/testdata/resp-error.plist
+++ b/workflow/certprof/testdata/resp-error.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CommandUUID</key>
+	<string>D053EE3A-EE0E-4E82-87D2-BB3624186694</string>
+	<key>ErrorChain</key>
+	<array>
+		<dict>
+			<key>ErrorCode</key>
+			<integer>-909</integer>
+			<key>ErrorDomain</key>
+			<string>NSOSStatusErrorDomain</string>
+			<key>LocalizedDescription</key>
+			<string> &lt;NSOSStatusErrorDomain:-909&gt;</string>
+		</dict>
+	</array>
+	<key>Status</key>
+	<string>Error</string>
+	<key>UDID</key>
+	<string>6362F867-FFF2-4EA6-905C-3C796DF4EF68</string>
+</dict>
+</plist>

--- a/workflow/certprof/testdata/scep.mobileconfig
+++ b/workflow/certprof/testdata/scep.mobileconfig
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadContent</key>
+			<dict>
+				<key>Challenge</key>
+				<string>%CHAL%</string>
+				<key>Key Type</key>
+				<string>RSA</string>
+				<key>Key Usage</key>
+				<integer>5</integer>
+				<key>Keysize</key>
+				<integer>2048</integer>
+				<key>Subject</key>
+				<array>
+					<array>
+						<array>
+							<string>CN</string>
+							<string>%CN%</string>
+						</array>
+					</array>
+				</array>
+				<key>URL</key>
+				<string>http://www.example.com/scep</string>
+			</dict>
+			<key>PayloadDisplayName</key>
+			<string>My SCEP</string>
+			<key>PayloadIdentifier</key>
+			<string>com.example.scep.scep</string>
+			<key>PayloadType</key>
+			<string>com.apple.security.scep</string>
+			<key>PayloadUUID</key>
+			<string>6E43D5BB-CBF2-4AF7-AA00-6AD3EC607AA9</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>Example SCEP</string>
+	<key>PayloadIdentifier</key>
+	<string>com.example.scep</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>99DE38CA-FE94-49EA-BADB-768D89049973</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/workflow/certprof/workflow.go
+++ b/workflow/certprof/workflow.go
@@ -1,0 +1,85 @@
+// Package certprof implements a NanoCMD Workflow installs a profile based on
+// a certificate list command response.
+package certprof
+
+import (
+	"context"
+
+	"github.com/micromdm/nanocmd/subsystem/profile/storage"
+	"github.com/micromdm/nanocmd/utils/uuid"
+	"github.com/micromdm/nanocmd/workflow"
+
+	"github.com/micromdm/nanolib/log"
+)
+
+const (
+	WorkflowName = "io.micromdm.wf.certprof.v1"
+
+	stepNameProfile = "profile"
+)
+
+// Workflow is a workflow that conditionally installs profiles based on the list of certificates.
+type Workflow struct {
+	enq    workflow.StepEnqueuer
+	ider   uuid.IDer
+	store  storage.ReadRawStorage
+	logger log.Logger
+}
+
+type Option func(*Workflow) error
+
+// WithLogger configures logger on the workflow.
+func WithLogger(logger log.Logger) Option {
+	return func(w *Workflow) error {
+		w.logger = logger
+		return nil
+	}
+}
+
+func New(enq workflow.StepEnqueuer, store storage.ReadRawStorage, opts ...Option) (*Workflow, error) {
+	if enq == nil {
+		panic("nil enqueuer")
+	}
+	if store == nil {
+		panic("nil store")
+	}
+	w := &Workflow{
+		enq:    enq,
+		ider:   uuid.NewUUID(),
+		store:  store,
+		logger: log.NopLogger,
+	}
+	for _, opt := range opts {
+		if err := opt(w); err != nil {
+			return nil, err
+		}
+	}
+	return w, nil
+}
+
+// Name returns [WorkflowName].
+func (w *Workflow) Name() string {
+	return WorkflowName
+}
+
+// Config returns nil. This workflow does not specify a workflow Conifg.
+func (w *Workflow) Config() *workflow.Config {
+	return nil
+}
+
+// NewContextValue returns a new [Context] regardless of input.
+func (w *Workflow) NewContextValue(_ string) workflow.ContextMarshaler {
+	return new(Context)
+}
+
+// StepTimeout is a stub handler for the workflow interface.
+// This workflow does not support step timeout handling.
+func (w *Workflow) StepTimeout(_ context.Context, _ *workflow.StepResult) error {
+	return workflow.ErrTimeoutNotUsed
+}
+
+// Event is a stub handler for the workflow interface.
+// This workflow does not support events.
+func (w *Workflow) Event(ctx context.Context, e *workflow.Event, id string, mdmCtx *workflow.MDMContext) error {
+	return workflow.ErrEventsNotSupported
+}

--- a/workflow/certprof/workflow_test.go
+++ b/workflow/certprof/workflow_test.go
@@ -1,0 +1,169 @@
+package certprof
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jessepeterson/mdmcommands"
+	"github.com/micromdm/nanocmd/engine"
+	enginestorage "github.com/micromdm/nanocmd/engine/storage/inmem"
+	"github.com/micromdm/nanocmd/subsystem/profile/storage"
+	"github.com/micromdm/nanocmd/subsystem/profile/storage/inmem"
+	"github.com/micromdm/nanocmd/utils/mobileconfig"
+	"github.com/micromdm/nanocmd/utils/uuid"
+	"github.com/micromdm/nanocmd/workflow/test"
+)
+
+func loadTestProfile(ctx context.Context, s storage.Storage, name string) error {
+	var profile mobileconfig.Mobileconfig
+	var err error
+
+	profile, err = os.ReadFile("testdata/scep.mobileconfig")
+	if err != nil {
+		return err
+	}
+
+	payload, _, err := profile.Parse()
+	if err != nil {
+		return err
+	}
+
+	return s.StoreProfile(
+		ctx,
+		name,
+		storage.ProfileInfo{Identifier: payload.PayloadIdentifier, UUID: payload.PayloadUUID},
+		profile,
+	)
+}
+
+func TestWorkflow(t *testing.T) {
+	e := engine.New(enginestorage.New(), &test.NullEnqueuer{})
+
+	c := test.NewCollectingStepEnqueur(e)
+
+	s := inmem.New()
+
+	ctx := context.Background()
+
+	err := loadTestProfile(ctx, s, "scep")
+	if err != nil {
+		t.Fatal()
+	}
+
+	w, err := New(c, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.ider = uuid.NewStaticIDs(
+		// note: order is important and depends on values in plist testdata
+		"CERT-LIST-01",
+		"D053EE3A-EE0E-4E82-87D2-BB3624186694",
+	)
+
+	// enrollment id
+	id := "6362F867-FFF2-4EA6-905C-3C796DF4EF68"
+
+	e.RegisterWorkflow(w)
+
+	// read it back out of the engine
+	w2 := e.Workflow(w.Name()).(*Workflow)
+
+	if w.Name() != w2.Name() {
+		t.Fatal("workflow name not equal after registration")
+	}
+
+	const testCtx = `{
+    "criteria": {
+        "always_replace": true
+    },
+    "filter": {
+        "cn_prefix": "?Error"
+    },
+    "profile": "scep",
+    "text_replacements": {
+        "%CN%": "324429DE-46B4-4209-AF95-82D9D8942A0E",
+        "%CHAL%": "D6E71C89-4831-4B88-9F1F-83714D526C63"
+    }
+}`
+
+	_, err = e.StartWorkflow(ctx, w.Name(), []byte(testCtx), []string{id}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	steps := c.Steps()
+
+	// make sure at least one step has been accumulated. the cert list.
+	if want, have := 1, len(steps); want != have {
+		t.Fatalf("wanted: %d; have: %d", want, have)
+	}
+
+	step := steps[0]
+
+	// make sure that step has ids
+	if want, have := 1, len(step.StepEnqueueing.IDs); want != have {
+		t.Fatalf("wanted: %d; have: %d", want, have)
+	}
+	// make sure the first id is the id the workflow was started for
+	if want, have := id, step.StepEnqueueing.IDs[0]; want != have {
+		t.Errorf("wanted: %s; have: %s", want, have)
+	}
+	// make sure the enqueued step had one command
+	if want, have := 1, len(step.Commands); want != have {
+		t.Fatalf("wanted: %d; have: %d", want, have)
+	}
+
+	err = test.SendCommandEvent(ctx, e, "testdata/certlist.plist", id, "CERT-LIST-01")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	steps = c.Steps()
+
+	// should have acculated two steps now. the install profile.
+	if want, have := 2, len(steps); want != have {
+		t.Fatalf("wanted: %d; have: %d", want, have)
+	}
+
+	step = steps[1]
+
+	// make sure that step has ids
+	if want, have := 1, len(step.StepEnqueueing.IDs); want != have {
+		t.Fatalf("wanted: %d; have: %d", want, have)
+	}
+	// make sure the first id is the id the workflow was started for
+	if want, have := id, step.StepEnqueueing.IDs[0]; want != have {
+		t.Errorf("wanted: %s; have: %s", want, have)
+	}
+	// make sure the enqueued step had one command
+	if want, have := 1, len(step.Commands); want != have {
+		t.Fatalf("wanted: %d; have: %d", want, have)
+	}
+
+	cmd := step.Commands[0].(*mdmcommands.InstallProfileCommand)
+	installProfile := mobileconfig.Mobileconfig(cmd.Command.Payload)
+	_, _, err = installProfile.Parse()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// validate UUID (second in static list, above)
+	if want, have := "D053EE3A-EE0E-4E82-87D2-BB3624186694", cmd.CommandUUID; want != have {
+		t.Errorf("wanted: %s; have: %s", want, have)
+	}
+
+	// verify profile has the replaced values
+	if !bytes.Contains(installProfile, []byte("<string>324429DE-46B4-4209-AF95-82D9D8942A0E</string>")) {
+		t.Error("profile does not contain magic value 1")
+	}
+	if !bytes.Contains(installProfile, []byte("<string>D6E71C89-4831-4B88-9F1F-83714D526C63</string>")) {
+		t.Error("profile does not contain magic value 1")
+	}
+
+	err = test.SendCommandEvent(ctx, e, "testdata/resp-ack.plist", id, "D053EE3A-EE0E-4E82-87D2-BB3624186694")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/workflow/context.go
+++ b/workflow/context.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 )
 
+var ErrInvalidContext = errors.New("invalid context")
+
 // ContextMarshaler marshals and unmarshals types to and from byte slices.
 // This encapsulates arbitrary context types to be passed around and
 // stored as binary blobs by components (that are not a workflow ) that

--- a/workflow/step.go
+++ b/workflow/step.go
@@ -54,7 +54,7 @@ type StepStart struct {
 	IDs   []string // Enrollment IDs
 }
 
-// StepEnqueueing preserves some context and IDs from step for enqueueing.
+// NewStepEnqueueing preserves some context and IDs from step for enqueueing.
 func (step *StepStart) NewStepEnqueueing() *StepEnqueueing {
 	if step == nil {
 		return nil
@@ -72,7 +72,7 @@ type StepResult struct {
 	CommandResults []interface{}
 }
 
-// StepEnqueueing preserves some context and IDs from step for enqueueing.
+// NewStepEnqueueing preserves some context and IDs from step for enqueueing.
 func (step *StepResult) NewStepEnqueueing() *StepEnqueueing {
 	if step == nil {
 		return nil

--- a/workflow/test/enqueue.go
+++ b/workflow/test/enqueue.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"context"
+	"sync"
+
+	"github.com/micromdm/nanocmd/workflow"
+)
+
+// NullEnqueuer is an enqueuer that doesn't do anything.
+type NullEnqueuer struct{}
+
+// Enqueue does nothing and returns nil.
+func (n *NullEnqueuer) Enqueue(_ context.Context, _ []string, _ []byte) error { return nil }
+
+// SupportsMultiCommands returns true.
+func (n *NullEnqueuer) SupportsMultiCommands() bool { return true }
+
+type CollectedStep struct {
+	WorkflowName string
+	*workflow.StepEnqueueing
+}
+
+type CollectingStepEnqueur struct {
+	next   workflow.StepEnqueuer
+	steps  []CollectedStep
+	stepMu sync.RWMutex
+}
+
+func NewCollectingStepEnqueur(next workflow.StepEnqueuer) *CollectingStepEnqueur {
+	return &CollectingStepEnqueur{next: next}
+}
+
+func (c *CollectingStepEnqueur) Steps() []CollectedStep {
+	c.stepMu.RLock()
+	defer c.stepMu.RUnlock()
+	return c.steps
+}
+
+func (c *CollectingStepEnqueur) EnqueueStep(ctx context.Context, n workflow.Namer, es *workflow.StepEnqueueing) error {
+	c.stepMu.Lock()
+	c.steps = append(c.steps, CollectedStep{
+		WorkflowName:   n.Name(),
+		StepEnqueueing: es,
+	})
+	c.stepMu.Unlock()
+	return c.next.EnqueueStep(ctx, n, es)
+}

--- a/workflow/test/event.go
+++ b/workflow/test/event.go
@@ -1,0 +1,49 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/jessepeterson/mdmcommands"
+	"github.com/micromdm/nanocmd/workflow"
+	"github.com/micromdm/plist"
+)
+
+type MDMCommandEventer interface {
+	MDMCommandResponseEvent(ctx context.Context, id string, uuid string, raw []byte, mdmContext *workflow.MDMContext) error
+}
+
+func SendCommandEvent(
+	ctx context.Context,
+	eventer MDMCommandEventer,
+	filePath string,
+	id string,
+	commandUUID string,
+) error {
+	// read the response file
+	raw, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("reading raw command: %w", err)
+	}
+
+	// make sure we can parse it
+	genResp := new(mdmcommands.GenericResponse)
+	err = plist.Unmarshal(raw, genResp)
+	if err != nil {
+		return fmt.Errorf("parsing generic command response: %w", err)
+	}
+
+	// check command UUID matches
+	if want, have := commandUUID, genResp.CommandUUID; want != have {
+		return fmt.Errorf("command UUIDs do not match: %s != %s", want, have)
+	}
+
+	// check UDID matches
+	if want, have := &id, genResp.UDID; *want != *have {
+		return fmt.Errorf("response UDIDs do not match: %s != %s", *want, *have)
+	}
+
+	// send the event
+	return eventer.MDMCommandResponseEvent(ctx, id, commandUUID, raw, nil)
+}


### PR DESCRIPTION
Creates a new `io.micromdm.wf.certprof.v1` workflow. See the operations docs in the PR for documentation, but:

> The certificate-profile workflow conditionally installs configuration profiles (ostensibly certificate identity profiles) based on output from the MDM `CertificateList` command.