### PR TITLE
fix(engine): log command UUIDs when enqueueing workflow steps

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -238,22 +238,38 @@ func (e *Engine) EnqueueStep(ctx context.Context, n workflow.Namer, se *workflow
 		return fmt.Errorf("storing step: %w", err)
 	}
 
+	stepLogger := ctxlog.Logger(ctx, e.logger).With(
+		logkeys.InstanceID, ss.InstanceID,
+		logkeys.GenericCount, len(ss.IDs),
+		logkeys.WorkflowName, ss.WorkflowName,
+		logkeys.StepName, ss.Name,
+	)
+	if len(ss.IDs) > 0 {
+		stepLogger = stepLogger.With(
+			logkeys.EnrollmentID, ss.IDs[0],
+			logkeys.FirstEnrollmentID, ss.IDs[0],
+		)
+	}
+
 	if ss.NotUntil.IsZero() {
 		// if we are not delaying the steps, then send them now
 		for _, cmd := range ss.Commands {
+			// associate the workflow instance with the individual command
+			// UUIDs we're about to enqueue. note the worker logs the same
+			// keys for delayed (NotUntil) steps.
+			cmdLogger := stepLogger.With(
+				logkeys.CommandUUID, cmd.CommandUUID,
+				logkeys.RequestType, cmd.RequestType,
+			)
 			if err = e.enqueuer.Enqueue(ctx, ss.IDs, cmd.Command); err != nil {
-				return fmt.Errorf("enqueueing step: %w", err)
+				return fmt.Errorf("enqueueing step command %s (%s): %w", cmd.CommandUUID, cmd.RequestType, err)
 			}
+			cmdLogger.Debug(logkeys.Message, "enqueued step command")
 		}
 	}
 
-	ctxlog.Logger(ctx, e.logger).Debug(
+	stepLogger.Debug(
 		logkeys.Message, "enqueued step",
-		logkeys.InstanceID, ss.InstanceID,
-		logkeys.GenericCount, len(ss.IDs),
-		logkeys.FirstEnrollmentID, ss.IDs[0],
-		logkeys.WorkflowName, ss.WorkflowName,
-		logkeys.StepName, ss.Name,
 		"command_count", len(ss.Commands),
 	)
 

--- a/engine/worker.go
+++ b/engine/worker.go
@@ -124,8 +124,13 @@ func (w *Worker) processEnqueuings(ctx context.Context) error {
 			logkeys.WorkflowName, step.WorkflowName,
 			logkeys.StepName, step.Name,
 			logkeys.GenericCount, len(step.IDs),
-			logkeys.FirstEnrollmentID, step.IDs[0],
 		)
+		if len(step.IDs) > 0 {
+			stepLogger = stepLogger.With(
+				logkeys.EnrollmentID, step.IDs[0],
+				logkeys.FirstEnrollmentID, step.IDs[0],
+			)
+		}
 		if len(step.Commands) < 1 {
 			stepLogger.Info()
 		}


### PR DESCRIPTION
EnqueueStep logged an instance ID and command count but never the command UUIDs, so logs couldn't tie an instance to the commands it sent. Log a line per command with command_uuid and request_type, as the worker already does for delayed steps.

Verified with gofmt, go vet ./engine/..., and make test — all pass.

Assisted-by: Claude Code:claude-opus-5